### PR TITLE
Add Claude Code SessionStart hook for dependency installation

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only run in remote (Claude Code on the web) environment
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "$CLAUDE_PROJECT_DIR"
+
+# Install a compatible Bundler 2.x version (the lockfile requires Bundler 2.x,
+# and the pre-installed Bundler 4.x has CGI compatibility issues with Ruby 3.3)
+gem install bundler -v '~> 2.5' --no-document
+
+# Install Ruby dependencies via Bundler
+BUNDLE_SILENCE_ROOT_WARNING=1 bundle _2.7.2_ install

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Sets up a session-start hook that installs a compatible Bundler 2.x
version and runs bundle install in remote (Claude Code on the web)
environments. This ensures Ruby dependencies are available when
starting new sessions.

https://claude.ai/code/session_01KBGG6AzHzLKhS3yVQmoLhJ